### PR TITLE
Recognize more versions of the iTunes library file

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,8 +25,8 @@
 
   <properties>
    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-   <maven.compiler.source>1.6</maven.compiler.source>
-   <maven.compiler.target>1.6</maven.compiler.target>
+   <maven.compiler.source>1.8</maven.compiler.source>
+   <maven.compiler.target>1.8</maven.compiler.target>
   </properties>
 
   <licenses>
@@ -44,8 +44,8 @@
      <artifactId>maven-compiler-plugin</artifactId>
      <version>3.1</version>
      <configuration>
-      <source>1.6</source>
-      <target>1.6</target>
+      <source>1.8</source>
+      <target>1.8</target>
      </configuration>
     </plugin>
    </plugins>

--- a/titl-core/src/main/java/org/kafsemo/titl/ProcessLibrary.java
+++ b/titl-core/src/main/java/org/kafsemo/titl/ProcessLibrary.java
@@ -113,7 +113,10 @@ public class ProcessLibrary
 
                 /* Did we hit the end? */
                 if(type.equals("hdsm")) {
-                    going = !ParseLibrary.readHdsm(new InputImpl(new ByteArrayInputStream(ba)), ba.length);
+                    ParseLibrary.HdsmData hd = ParseLibrary.readHdsm(new InputImpl(new ByteArrayInputStream(ba)), ba.length);
+                    going = !hd.shouldStop;
+                    consumed += hd.extraDataLength;
+                    remaining -= hd.extraDataLength;
                 }
 
                 remaining -= length;

--- a/titl-core/src/main/java/org/kafsemo/titl/Track.java
+++ b/titl-core/src/main/java/org/kafsemo/titl/Track.java
@@ -39,7 +39,12 @@ public class Track
     private int rating;
     private String url;
     private byte[] albumPersistentId;
-    
+    private int trackNumber;
+    private int trackCount;
+    private int discNumber;
+    private int discCount;
+    private boolean isCompilation;
+
     public int getTrackId()
     {
         return trackId;
@@ -147,6 +152,56 @@ public class Track
     public int getLibraryFolderCount() {
         // TODO Auto-generated method stub
         return -1;
+    }
+
+    public int getTrackNumber()
+    {
+        return trackNumber;
+    }
+
+    public void setTrackNumber(int trackNumber)
+    {
+        this.trackNumber = trackNumber;
+    }
+
+    public int getTrackCount()
+    {
+        return trackCount;
+    }
+
+    public void setTrackCount(int trackCount)
+    {
+        this.trackCount = trackCount;
+    }
+
+    public int getDiscNumber()
+    {
+        return discNumber;
+    }
+
+    public void setDiscNumber(int discNumber)
+    {
+        this.discNumber = discNumber;
+    }
+
+    public int getDiscCount()
+    {
+        return discCount;
+    }
+
+    public void setDiscCount(int discCount)
+    {
+        this.discCount = discCount;
+    }
+
+    public boolean isCompilation()
+    {
+        return isCompilation;
+    }
+
+    public void setCompilation(boolean compilation)
+    {
+        isCompilation = compilation;
     }
 
     public void setTrackId(int trackId)
@@ -321,7 +376,7 @@ public class Track
     {
         this.albumPersistentId = id;
     }
-    
+
     public byte[] getAlbumPersistentId()
     {
         return albumPersistentId;
@@ -336,7 +391,7 @@ public class Track
     {
         this.playcount = playcount;
     }
-    
+
     public int getPlayCount()
     {
         return this.playcount;
@@ -350,7 +405,7 @@ public class Track
             this.playDate = null;
         }
     }
-    
+
     public Date getLastPlayDate()
     {
         return this.playDate;


### PR DESCRIPTION
I have made some changes that allow the parser to recognize newer formats of the iTunes library file.
I have tested these changes by examining the tracks that it finds in several of the files in Previous iTunes Libraries.
These changes break several of the existing tests.
As these tests were created many years ago, they may not be valid.
I have accomplished my goals and do not plan to do any further work on this project.
I am submitting my changes in case anyone finds them useful.
